### PR TITLE
Update plumbing and schema

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
 
-  :dependencies [[prismatic/plumbing "0.4.0"]
-                 [prismatic/schema "0.4.0"]
+  :dependencies [[prismatic/plumbing "0.4.4"]
+                 [prismatic/schema "0.4.3"]
                  [org.clojure/clojurescript "0.0-2665" :scope "provided"]
                  [om "0.7.3" :scope "provided"]]
 


### PR DESCRIPTION
schema 0.4.1 resolves several warnings (https://github.com/Prismatic/schema/issues/192)

These warnings are very spammy when combined with figwheel.